### PR TITLE
Add Causemos containers to integration

### DIFF
--- a/dart-standalone.yml
+++ b/dart-standalone.yml
@@ -591,13 +591,14 @@ services:
   causemos-elasticsearch:
     image: uncharted/wm-causemos-elastic:latest
     healthcheck:
-        test: ["CMD", "curl", "-f", "http://localhost:9203"]
+        test: ["CMD", "curl", "-f", "http://causemos-elasticsearch:9200"]
         interval: 30s
         timeout: 10s
         retries: 5
     environment:
       - xpack.security.enabled=false
       - "discovery.type=single-node"
+      - cluster.routing.allocation.disk.threshold_enabled=false
     networks:
       - dart
     ports:
@@ -616,14 +617,12 @@ services:
     depends_on:
       causemos-elasticsearch:
         condition: service_healthy
-    #secrets:
-    #  - source: CAUSEMOS_ENV_FILE
-    #    target: /server/.env
     environment:
       TD_DATA_URL: http://causemos-elasticsearch:9200
       DART_SERVICE_URL: http://traefik/dart/api/v1
       DART_DOCUMENT_RETRIEVAL_URL: http://traefik/dart/api/v1
       INDRA_URL: http://indra:8000
+      WM_GO_URL: UNUSED
     networks:
       - dart
     ports:
@@ -643,9 +642,6 @@ services:
       SOURCE_ES: http://causemos-elasticsearch:9200
       TARGET_ES: http://causemos-elasticsearch:9200
       INDRA_HOST: http://indra:8000
-    #secrets:
-    #  - source: ANANSI_ENV_FILE
-    #    target: /web/.env
     networks:
       - dart
     ports:

--- a/dart-standalone.yml
+++ b/dart-standalone.yml
@@ -588,6 +588,71 @@ services:
     networks:
       - dart
 
+  causemos-elasticsearch:
+    image: uncharted/wm-causemos-elastic:latest
+    healthcheck:
+        test: ["CMD", "curl", "-f", "http://localhost:9203"]
+        interval: 30s
+        timeout: 10s
+        retries: 5
+    environment:
+      - xpack.security.enabled=false
+      - "discovery.type=single-node"
+    networks:
+      - dart
+    ports:
+      - 9203:9200
+
+  causemos:
+    image: uncharted/wm-causemos:latest
+    deploy:
+      placement:
+        constraints: [node.role != manager]
+      replicas: 1
+      resources:
+        limits:
+          memory: 1048M
+          cpus: '2'
+    depends_on:
+      causemos-elasticsearch:
+        condition: service_healthy
+    #secrets:
+    #  - source: CAUSEMOS_ENV_FILE
+    #    target: /server/.env
+    environment:
+      TD_DATA_URL: http://causemos-elasticsearch:9200
+      DART_SERVICE_URL: http://traefik/dart/api/v1
+      DART_DOCUMENT_RETRIEVAL_URL: http://traefik/dart/api/v1
+      INDRA_URL: http://indra:8000
+    networks:
+      - dart
+    ports:
+      - "3003:3000"
+
+  anansi:
+    image: uncharted/wm-causemos-anansi:latest
+    deploy:
+      placement:
+        constraints: [node.role != manager]
+      replicas: 1
+      resources:
+        limits:
+          memory: 1048M
+          cpus: '2'
+    environment:
+      SOURCE_ES: http://causemos-elasticsearch:9200
+      TARGET_ES: http://causemos-elasticsearch:9200
+      INDRA_HOST: http://indra:8000
+    #secrets:
+    #  - source: ANANSI_ENV_FILE
+    #    target: /web/.env
+    networks:
+      - dart
+    ports:
+      - "6000:6000"
+    volumes:
+      - ./data:/data
+
   autoheal:
     image: willfarrell/autoheal
     container_name: autoheal


### PR DESCRIPTION
This PR is an attempt to integrate Causemos into the Docker compose configuration. I haven't had a chance to test this out locally. The URLs defined as environment variables might not be quite right in all cases and should be reviewed/tested. Also, I left two blocks like
```
    #secrets:
    #  - source: CAUSEMOS_ENV_FILE
    #    target: /server/.env
```
commented out. Here, the original Causemos implementation refers to separate files that have environment variables configured in them, and it appears these are mounted into the container in a file visible within the container. If this is really necessary for Causemos to work, we might have to come up with a solution for it.