### PR TITLE
Connect Causemos-anansi to INDRA and DART

### DIFF
--- a/dart-standalone.yml
+++ b/dart-standalone.yml
@@ -642,6 +642,9 @@ services:
       SOURCE_ES: http://causemos-elasticsearch:9200
       TARGET_ES: http://causemos-elasticsearch:9200
       INDRA_HOST: http://indra:8000
+      WATCH_FOLDER: /data/indra
+      WATCH_INTERVAL: 60000
+      DART_CDR_URL: http://traefik/dart/api/v1/cdrs/archive 
     networks:
       - dart
     ports:


### PR DESCRIPTION
This PR adds additional environmental variables to the anansi container whose latest version can use these values to automatically ingest new assembled KBs from INDRA and pull CDR information from DART.